### PR TITLE
Future messages.

### DIFF
--- a/msg/impact.go
+++ b/msg/impact.go
@@ -9,6 +9,7 @@ import (
 
 var source = regexp.MustCompile(`^[a-zA-Z0-9\.\-]+$`)
 var MeasuredAge = time.Duration(-60) * time.Minute // measured intensity messages older than this are not saved to the DB.
+var future = time.Duration(10) * time.Second
 
 // Intensity is for measured or reported intensity messages e.g.,
 //  {
@@ -90,7 +91,7 @@ func (i *Intensity) Future() {
 		return
 	}
 
-	if i.Time.After(time.Now().UTC()) {
+	if i.Time.After(time.Now().UTC().Add(future)) {
 		i.err = fmt.Errorf("future message for %s", i.Source)
 	}
 

--- a/msg/impact_test.go
+++ b/msg/impact_test.go
@@ -57,10 +57,23 @@ func TestImpact(t *testing.T) {
 		t.Error("not future should have nil i.err.")
 	}
 
-	i.Time = time.Now().UTC().Add(time.Duration(30) * time.Minute)
+	i.Time = time.Now().UTC().Add(time.Duration(30) * time.Second)
 
 	i.Future()
 	if i.Err() == nil {
-		t.Error("future should have nil i.err.")
+		t.Error("future should have non nil i.err.")
+	}
+
+	i = Intensity{}
+
+	i.Source = "test.test"
+	i.Quality = "measured"
+	i.MMI = 4
+
+	i.Time = time.Now().UTC().Add(time.Duration(9) * time.Second)
+
+	i.Future()
+	if i.Err() != nil {
+		t.Error("less than 10s in the future should have nil i.err.")
 	}
 }


### PR DESCRIPTION
Allow intensity messages to be slightly into the future to allow for
phone clock errors.

Resolves #26.