### PR TITLE
Wip stats v2

### DIFF
--- a/geonet-rest/docs/index.md
+++ b/geonet-rest/docs/index.md
@@ -31,6 +31,7 @@ The code that provide these services is available at https://github.com/GeoNet/h
 * [News](#news)
 * [Quake](#quake)
 * [Quake History](#quakehistory)
+* [Quake Stats](#quakestats)
 * [Quakes](#quakes)
 * [Quake CAP](#quakecap)
 * [Quake CAP Feed](#quakecapfeed)
@@ -198,6 +199,27 @@ quality
 
 [/quake/history/2013p407387](/quake/history/2013p407387)
 
+## Quake Stats ## {#quakestats}
+
+Quake statistics. 
+
+ [GET] /quake/stats
+
+### Accept Version
+
+    application/vnd.geo+json;version=2
+
+### Response
+
+magnitudeCount
+:  contains three members that summarise magnitude by count over the last 7, 28, and 365 days.
+
+rate
+:  contains the member perDay that gives a per day summary by count of quake occurence.
+
+### Examples
+
+[/quake/stats](/quake/stats)
 
 ## Quakes ## {#quakes}
 

--- a/geonet-rest/docs/index.md
+++ b/geonet-rest/docs/index.md
@@ -23,7 +23,7 @@ Bugs
 
 ## Bugs
 
-The code that provide these services is available at https://github.com/GeoNet/haz/geonet-rest If you believe you have found a bug please raise an issue or pull request there.
+The code that provide these services is available at [https://github.com/GeoNet/haz/geonet-rest](https://github.com/GeoNet/haz/geonet-rest) If you believe you have found a bug please raise an issue or pull request there.
 
 # Endpoints
 

--- a/geonet-rest/intensityV2.go
+++ b/geonet-rest/intensityV2.go
@@ -23,18 +23,18 @@ func intensityV2(w http.ResponseWriter, r *http.Request) {
 
 	switch t {
 	case "measured":
-		d, err = measuredLatest()
+		err = db.QueryRow(intensityMeasuredLatestV2SQL).Scan(&d)
 	case "reported":
 		switch r.URL.Query().Get("publicID") {
 		case "":
-			d, err = reportedLatest()
+			err = db.QueryRow(intenstityReportedLatestV2SQL).Scan(&d)
 		default:
 			var t time.Time
 			var ok bool
 			if t, ok = getQuakeTime(w, r); !ok {
 				return
 			}
-			d, err = reportedWindow(t)
+			err = db.QueryRow(intenstityReportedWindowV2SQL, t.Add(time.Duration(-1*time.Minute)), t.Add(time.Duration(15*time.Minute))).Scan(&d)
 		}
 	}
 
@@ -46,90 +46,4 @@ func intensityV2(w http.ResponseWriter, r *http.Request) {
 	b := []byte(d)
 	w.Header().Set("Content-Type", web.V2GeoJSON)
 	web.Ok(w, r, &b)
-}
-
-func measuredLatest() (string, error) {
-	var d string
-	err := db.QueryRow(
-		`SELECT row_to_json(fc)
-				FROM ( SELECT 'FeatureCollection' as type, COALESCE(array_to_json(array_agg(f)), '[]') as features
-					FROM (SELECT 'Feature' as type,
-						ST_AsGeoJSON(s.location)::json as geometry,
-						row_to_json(( select l from 
-							( 
-								select mmi
-								) as l )) 
-			as properties from (select location, mmi 
-				FROM impact.intensity_measured) as s 
-			) As f )  as fc`).Scan(&d)
-	return d, err
-}
-
-func reportedLatest() (string, error) {
-	var d string
-	err := db.QueryRow(
-		`WITH features as (
-	select COALESCE(array_to_json(array_agg(fs)), '[]') as features from (SELECT 'Feature' as type,
-						ST_AsGeoJSON(s.location)::json as geometry,
-						row_to_json(( select l from 
-							( 
-							select mmi,
-							count
-							) as l )) 
-							as properties from (select st_pointfromgeohash(geohash6) as location, 
-							max(mmi) as mmi, 
-							count(mmi) as count 
-							FROM impact.intensity_reported 
-								WHERE time >= (now() - interval '60 minutes')
-							group by (geohash6)) as s) as fs
-		), summary as (
-			select COALESCE(json_object_agg(summ.mmi, summ.count), '{}') as count_mmi, COALESCE(sum(count), 0) as count
-			from (select mmi as mmi, count(*) as count from impact.intensity_reported 
-			WHERE time >= (now() - interval '60 minutes')
-			group by mmi
-			) as summ
-		)
-		SELECT row_to_json(fc)
-			FROM ( SELECT 'FeatureCollection' as type, 
-					features.features, 
-					summary.count_mmi,
-					summary.count
-				FROM features, summary )  as fc`).Scan(&d)
-	return d, err
-}
-
-func reportedWindow(t time.Time) (string, error) {
-	var d string
-	var err error
-
-	err = db.QueryRow(`WITH features as (
-	select COALESCE(array_to_json(array_agg(fs)), '[]') as features from (SELECT 'Feature' as type,
-						ST_AsGeoJSON(s.location)::json as geometry,
-						row_to_json(( select l from 
-							( 
-							select mmi,
-							count
-							) as l )) 
-							as properties from (select st_pointfromgeohash(geohash6) as location, 
-							max(mmi) as mmi, 
-							count(mmi) as count 
-							FROM impact.intensity_reported 
-								WHERE time >= $1
-								AND time <= $2
-							group by (geohash6)) as s) as fs
-		), summary as (
-			select COALESCE(json_object_agg(summ.mmi, summ.count), '{}') as count_mmi, COALESCE(sum(count), 0) as count
-			from (select mmi as mmi, count(*) as count from impact.intensity_reported 
-			WHERE time >= $1
-			AND time <= $2
-			group by mmi
-			) as summ
-		)
-		SELECT row_to_json(fc)
-			FROM ( SELECT 'FeatureCollection' as type, 
-					features.features, 
-					summary.count_mmi,
-					summary.count
-				FROM features, summary )  as fc`, t.Add(time.Duration(-1*time.Minute)), t.Add(time.Duration(15*time.Minute))).Scan(&d)
-	return d, err
 }

--- a/geonet-rest/quakeV2.go
+++ b/geonet-rest/quakeV2.go
@@ -86,3 +86,26 @@ func quakeHistoryV2(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", web.V2GeoJSON)
 	web.Ok(w, r, &b)
 }
+
+func quakeStatsV2(w http.ResponseWriter, r *http.Request) {
+	if badQuery(w, r, []string{}, []string{}) {
+		return
+	}
+
+	if len(r.URL.Query()) != 0 {
+		web.BadRequest(w, r, "incorrect number of query parameters.")
+		return
+	}
+
+	var d string
+	err := db.QueryRow(quakeStatsV2SQL).Scan(&d)
+	if err != nil {
+		web.ServiceUnavailable(w, r, err)
+		return
+	}
+
+	b := []byte(d)
+	w.Header().Set("Surrogate-Control", web.MaxAge300)
+	w.Header().Set("Content-Type", web.V2JSON)
+	web.Ok(w, r, &b)
+}

--- a/geonet-rest/quakeV2.go
+++ b/geonet-rest/quakeV2.go
@@ -23,23 +23,7 @@ func quakeV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var d string
-	err := db.QueryRow(
-		`SELECT row_to_json(fc)
-                         FROM ( SELECT 'FeatureCollection' as type, array_to_json(array_agg(f)) as features
-                         FROM (SELECT 'Feature' as type,
-                         ST_AsGeoJSON(q.geom)::json as geometry,
-                         row_to_json((SELECT l FROM 
-                         	(
-                         		SELECT 
-                         		publicid AS "publicID",
-                                to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "time",
-                                depth, 
-                                magnitude, 
-                                locality,
-                                floor(mmid_newzealand) as "mmi",
-                                quality
-                           ) as l
-                         )) as properties FROM haz.quake as q where publicid = $1 ) As f )  as fc`, publicID).Scan(&d)
+	err := db.QueryRow(quakeV2SQL, publicID).Scan(&d)
 	if err != nil {
 		web.ServiceUnavailable(w, r, err)
 		return
@@ -63,25 +47,7 @@ func quakesV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var d string
-	err := db.QueryRow(
-		`SELECT row_to_json(fc)
-                         FROM ( SELECT 'FeatureCollection' as type, COALESCE(array_to_json(array_agg(f)), '[]') as features
-                         FROM (SELECT 'Feature' as type,
-                         ST_AsGeoJSON(q.geom)::json as geometry,
-                         row_to_json((SELECT l FROM
-                         	(
-                         		SELECT
-                         		publicid AS "publicID",
-                                to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "time",
-                                depth,
-                                magnitude,
-                                locality,
-                                floor(mmid_newzealand) as "mmi",
-                                quality
-                           ) as l
-                         )) as properties FROM haz.quakeapi as q where mmid_newzealand >= $1
-		AND In_newzealand = true
-                         ORDER BY time DESC  limit 100 ) as f ) as fc`, mmi).Scan(&d)
+	err := db.QueryRow(quakesV2SQL, mmi).Scan(&d)
 	if err != nil {
 		web.ServiceUnavailable(w, r, err)
 		return
@@ -110,24 +76,7 @@ func quakeHistoryV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var d string
-	err := db.QueryRow(
-		`SELECT row_to_json(fc)
-                         FROM ( SELECT 'FeatureCollection' as type, array_to_json(array_agg(f)) as features
-                         FROM (SELECT 'Feature' as type,
-                         ST_AsGeoJSON(q.geom)::json as geometry,
-                         row_to_json((SELECT l FROM 
-                         	(
-                         		SELECT 
-                         		publicid AS "publicID",
-                                to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "time",
-                                to_char(modificationtime, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "modificationTime",
-                                depth, 
-                                magnitude, 
-                                locality,
-                                floor(mmid_newzealand) as "mmi",
-                                quality
-                           ) as l
-                         )) as properties FROM haz.quakehistory as q where publicid = $1 order by modificationtime desc ) As f )  as fc`, publicID).Scan(&d)
+	err := db.QueryRow(quakeHistoryV2SQL, publicID).Scan(&d)
 	if err != nil {
 		web.ServiceUnavailable(w, r, err)
 		return

--- a/geonet-rest/quakeV2_test.go
+++ b/geonet-rest/quakeV2_test.go
@@ -253,3 +253,68 @@ func TestQuakeHistoryV2(t *testing.T) {
 		t.Error("didn't find quake 2013p407387 in the list of Features.")
 	}
 }
+
+type magCountV2 struct {
+	MagnitudeCount struct {
+		Days7   map[string]int
+		Days28  map[string]int
+		Days365 map[string]int
+	}
+	Rate struct {
+		PerDay map[string]int
+	}
+}
+
+func TestQuakeStatsV2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	c := webtest.Content{
+		Accept: web.V2JSON,
+		URI:    "/quake/stats",
+	}
+
+	b, err := c.Get(ts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var m magCountV2
+
+	err = json.Unmarshal(b, &m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.MagnitudeCount.Days28["4"] != 1 {
+		t.Errorf("exptected 1 got %d", m.MagnitudeCount.Days28["4"])
+	}
+
+	if m.MagnitudeCount.Days28["5"] != 1 {
+		t.Errorf("exptected 1 got %d", m.MagnitudeCount.Days28["5"])
+	}
+
+	if m.MagnitudeCount.Days7["4"] != 1 {
+		t.Errorf("exptected 1 got %d", m.MagnitudeCount.Days7["4"])
+	}
+
+	if m.MagnitudeCount.Days7["5"] != 1 {
+		t.Errorf("exptected 1 got %d", m.MagnitudeCount.Days7["5"])
+	}
+
+	if m.MagnitudeCount.Days365["4"] != 1 {
+		t.Errorf("exptected 1 got %d", m.MagnitudeCount.Days365["4"])
+	}
+
+	if m.MagnitudeCount.Days365["5"] != 1 {
+		t.Errorf("exptected 1 got %d", m.MagnitudeCount.Days365["5"])
+	}
+
+	if m.MagnitudeCount.Days28["6"] != 0 {
+		t.Errorf("exptected 0 got %d", m.MagnitudeCount.Days28["6"])
+	}
+
+	if m.Rate.PerDay["2015-11-03T00:00:00+00:00"] != 2 {
+		t.Errorf("expected 2 for daily rate, got %d", m.Rate.PerDay["2015-11-03T00:00:00+00:00"])
+	}
+}

--- a/geonet-rest/quakeV2_test.go
+++ b/geonet-rest/quakeV2_test.go
@@ -314,7 +314,13 @@ func TestQuakeStatsV2(t *testing.T) {
 		t.Errorf("exptected 0 got %d", m.MagnitudeCount.Days28["6"])
 	}
 
-	if m.Rate.PerDay["2015-11-03T00:00:00+00:00"] != 2 {
-		t.Errorf("expected 2 for daily rate, got %d", m.Rate.PerDay["2015-11-03T00:00:00+00:00"])
+	if len(m.Rate.PerDay) != 1 {
+		t.Errorf("expected 1 for daily rate, got %d", len(m.Rate.PerDay))
+	}
+
+	for k, _ := range m.Rate.PerDay {
+		if m.Rate.PerDay[k] != 2 {
+			t.Errorf("expected 2 quakes for day %s", k)
+		}
 	}
 }

--- a/geonet-rest/routes.go
+++ b/geonet-rest/routes.go
@@ -33,6 +33,7 @@ func init() {
 
 	muxV2JSON = http.NewServeMux()
 	muxV2JSON.HandleFunc("/news/geonet", newsV2)
+	muxV2JSON.HandleFunc("/quake/stats", quakeStatsV2)
 
 	// muxDefault handles routes with no Accept version.
 	muxDefault = http.NewServeMux()
@@ -45,6 +46,7 @@ func init() {
 	muxDefault.HandleFunc("/quake/", quakeV2)
 	muxDefault.HandleFunc("/quake", quakesV2)
 	muxDefault.HandleFunc("/quake/history/", quakeHistoryV2)
+	muxDefault.HandleFunc("/quake/stats", quakeStatsV2)
 	muxDefault.HandleFunc("/intensity", intensityV2)
 	muxDefault.HandleFunc("/news/geonet", newsV2)
 

--- a/geonet-rest/routes_test.go
+++ b/geonet-rest/routes_test.go
@@ -124,6 +124,7 @@ func TestRoutes(t *testing.T) {
 		TestAccept: false,
 	}
 	r.Add("/news/geonet")
+	r.Add("/quake/stats")
 
 	r.Test(ts, t)
 

--- a/geonet-rest/sql_queries.go
+++ b/geonet-rest/sql_queries.go
@@ -1,0 +1,147 @@
+package main
+
+const quakeV2SQL = `SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type, array_to_json(array_agg(f)) as features
+	FROM (SELECT 'Feature' as type,
+		ST_AsGeoJSON(q.geom)::json as geometry,
+		row_to_json((SELECT l FROM 
+			(
+				SELECT 
+				publicid AS "publicID",
+				to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "time",
+				depth, 
+				magnitude, 
+				locality,
+				floor(mmid_newzealand) as "mmi",
+				quality
+				) as l
+)) as properties FROM haz.quake as q where publicid = $1 ) As f )  as fc`
+
+const quakesV2SQL = `SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type, COALESCE(array_to_json(array_agg(f)), '[]') as features
+	FROM (SELECT 'Feature' as type,
+		ST_AsGeoJSON(q.geom)::json as geometry,
+		row_to_json((SELECT l FROM
+			(
+				SELECT
+				publicid AS "publicID",
+				to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "time",
+				depth,
+				magnitude,
+				locality,
+				floor(mmid_newzealand) as "mmi",
+				quality
+				) as l
+)) as properties FROM haz.quakeapi as q where mmid_newzealand >= $1
+AND In_newzealand = true
+ORDER BY time DESC  limit 100 ) as f ) as fc`
+
+const quakeHistoryV2SQL = `SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type, array_to_json(array_agg(f)) as features
+	FROM (SELECT 'Feature' as type,
+		ST_AsGeoJSON(q.geom)::json as geometry,
+		row_to_json((SELECT l FROM 
+			(
+				SELECT 
+				publicid AS "publicID",
+				to_char(time, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "time",
+				to_char(modificationtime, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "modificationTime",
+				depth, 
+				magnitude, 
+				locality,
+				floor(mmid_newzealand) as "mmi",
+				quality
+				) as l
+)) as properties FROM haz.quakehistory as q where publicid = $1 order by modificationtime desc ) As f )  as fc`
+
+const intensityMeasuredLatestV2SQL = `SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type, COALESCE(array_to_json(array_agg(f)), '[]') as features
+	FROM (SELECT 'Feature' as type,
+		ST_AsGeoJSON(s.location)::json as geometry,
+		row_to_json(( select l from 
+			( 
+				select mmi
+				) as l )) 
+as properties from (select location, mmi 
+	FROM impact.intensity_measured) as s 
+) As f )  as fc`
+
+const intenstityReportedLatestV2SQL = `WITH features as (
+	select COALESCE(array_to_json(array_agg(fs)), '[]') as features from (SELECT 'Feature' as type,
+		ST_AsGeoJSON(s.location)::json as geometry,
+		row_to_json(( select l from 
+			( 
+				select mmi,
+				count
+				) as l )) 
+as properties from (select st_pointfromgeohash(geohash6) as location, 
+	max(mmi) as mmi, 
+	count(mmi) as count 
+	FROM impact.intensity_reported 
+	WHERE time >= (now() - interval '60 minutes')
+	group by (geohash6)) as s) as fs
+), summary as (
+	select COALESCE(json_object_agg(summ.mmi, summ.count), '{}') as count_mmi, COALESCE(sum(count), 0) as count
+	from (select mmi as mmi, count(*) as count from impact.intensity_reported 
+		WHERE time >= (now() - interval '60 minutes')
+		group by mmi
+		) as summ
+)
+SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type, 
+	features.features, 
+	summary.count_mmi,
+	summary.count
+	FROM features, summary )  as fc`
+
+const intenstityReportedWindowV2SQL = `WITH features as (
+	select COALESCE(array_to_json(array_agg(fs)), '[]') as features from (SELECT 'Feature' as type,
+		ST_AsGeoJSON(s.location)::json as geometry,
+		row_to_json(( select l from 
+			( 
+				select mmi,
+				count
+				) as l )) 
+as properties from (select st_pointfromgeohash(geohash6) as location, 
+	max(mmi) as mmi, 
+	count(mmi) as count 
+	FROM impact.intensity_reported 
+	WHERE time >= $1
+	AND time <= $2
+	group by (geohash6)) as s) as fs
+), summary as (
+	select COALESCE(json_object_agg(summ.mmi, summ.count), '{}') as count_mmi, COALESCE(sum(count), 0) as count
+	from (select mmi as mmi, count(*) as count from impact.intensity_reported 
+		WHERE time >= $1
+		AND time <= $2
+		group by mmi
+		) as summ
+)
+SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type, 
+	features.features, 
+	summary.count_mmi,
+	summary.count
+	FROM features, summary )  as fc`
+
+/*
+	There needs to be an Atom feed entity for every CAP message.
+	A CAP message ID is unique for each CAP message (and is not just the quake PublicID).
+	1. Find the first time any quake was reviewed within an hour of the quake
+	and was strong enough for a CAP message.  This is the first CAP message.
+	2. Select the first CAP message and any subsequent reviews or deletes that happened with an hour
+	of the quake.  Each of this is a CAP message and gets an entity in the feed.
+*/
+const capQuakeFeedSQL = `with first_review as 
+	(select publicid, min(modificationtimeunixmicro) as modificationtimeunixmicro 
+		from haz.quakehistory 
+		where status = 'reviewed' 
+		AND modificationTime - time < interval '1 hour' 
+		AND MMID_newzealand >= $1 
+		AND now() - time < interval '48 hours' group by publicid)
+select h.publicid, h.modificationtimeunixmicro, h.modificationTime 
+from haz.quakehistory h, first_review 
+where h.publicid = first_review.publicid 
+and h.modificationtimeunixmicro >= first_review.modificationtimeunixmicro 
+and status in ('reviewed','deleted') 
+AND modificationTime - time < interval '1 hour' ORDER BY time DESC, modificationTime DESC`


### PR DESCRIPTION
The first commit just pulls the existing SQL queries into their own file as string constants.  I was having problems with them getting changed during code formating - this should stop that.  It also makes the query handlers a little easier to read.

The second commit adds quake stats.  A sample output looks like:

```
{
"magnitudeCount": {
"days365": {
"4": 1,
"5": 1
},
"days28": {
"4": 1,
"5": 1
},
"days7": {
"4": 1,
"5": 1
}
},
"rate": {
"perDay": {
"2015-11-03T00:00:00+00:00": 2
}
}
}
```