### PR TITLE
Soh

### DIFF
--- a/geonet-rest/routes.go
+++ b/geonet-rest/routes.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+
 	"net/http"
 	"github.com/GeoNet/weft"
 )
@@ -35,9 +36,13 @@ func init() {
 	muxV2JSON.HandleFunc("/quake/stats", weft.MakeHandlerAPI(quakeStatsV2))
 
 	// muxDefault handles routes with no Accept version.
+	// soh routes
 	muxDefault = http.NewServeMux()
-	muxDefault.HandleFunc("/soh", weft.MakeHandlerAPI(soh))
-	muxDefault.HandleFunc("/soh/impact", weft.MakeHandlerAPI(impactSOH))
+	muxDefault.HandleFunc("/soh", http.HandlerFunc(soh))
+	muxDefault.HandleFunc("/soh/esb", http.HandlerFunc(sohEsb))
+	muxDefault.HandleFunc("/soh/up", http.HandlerFunc(up))
+	muxDefault.HandleFunc("/soh/impact", http.HandlerFunc(impactSOH))
+
 	muxDefault.HandleFunc("/cap/1.2/GPA1.0/quake/", weft.MakeHandlerAPI(capQuake))
 	muxDefault.HandleFunc("/cap/1.2/GPA1.0/feed/atom1.0/quake", weft.MakeHandlerAPI(capQuakeFeed))
 	// The 'latest' version of the API for unversioned requests.

--- a/geonet-rest/routes_test.go
+++ b/geonet-rest/routes_test.go
@@ -97,6 +97,12 @@ var routes = wt.Requests{
 	// V2 GeoJSON routes that should bad request
 	{ID: wt.L(), Accept: V2GeoJSON, Content: ErrContent, Surrogate: maxAge86400, Status: http.StatusBadRequest, URL: "/quake?MMI=9"},
 	{ID: wt.L(), Accept: V2GeoJSON, Content: ErrContent, Surrogate: maxAge86400, Status: http.StatusBadRequest, URL: "/quake?MMI=-2"},
+
+	// soh routes
+	{ID: wt.L(), URL: "/soh"},
+	{ID: wt.L(), URL: "/soh/up"},
+	{ID: wt.L(), URL: "/soh/esb"},
+	{ID: wt.L(), Status: http.StatusServiceUnavailable, URL: "/soh/impact"}, // not enough data so gets an error
 }
 
 // Test all routes give the expected response.  Also check with

--- a/quakesearch/quakes_test.go
+++ b/quakesearch/quakes_test.go
@@ -71,6 +71,10 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/kml?limit=100&bbox=163.60840,-49.18170,182.98828,-32.28713&minmag=3&maxmag=10", Content: CONTENT_TYPE_KML, Accept: CONTENT_TYPE_KML},
 	{ID: wt.L(), URL: "/kml?limit=100&bbox=163.60840,-49.18170,182.98828,-32.28713&mindepth=10&maxdepth=200", Content: CONTENT_TYPE_KML, Accept: CONTENT_TYPE_KML},
 	{ID: wt.L(), URL: "/kml?limit=100&region=canterbury&minmag=3&maxmag=7&mindepth=1&maxdepth=200", Content: CONTENT_TYPE_KML, Accept: CONTENT_TYPE_KML},
+
+	// soh routes
+	{ID: wt.L(), URL: "/soh"},
+	{ID: wt.L(), URL: "/soh/up"},
 }
 
 func TestRoutes(t *testing.T) {

--- a/quakesearch/router.go
+++ b/quakesearch/router.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+
 	"bytes"
 	"github.com/GeoNet/weft"
 	"html/template"
 	"net/http"
 	"os"
+	"log"
 )
 
 var (
@@ -24,6 +26,10 @@ func init() {
 	serveMux.HandleFunc("/gml", weft.MakeHandlerAPI(getQuakesGml))
 	serveMux.HandleFunc("/kml", weft.MakeHandlerAPI(getQuakesKml))
 	serveMux.HandleFunc("/", weft.MakeHandlerPage(indexPage))
+
+	// routes for balancers and probes.
+	serveMux.HandleFunc("/soh/up", http.HandlerFunc(up))
+	serveMux.HandleFunc("/soh", http.HandlerFunc(soh))
 }
 
 func router(w http.ResponseWriter, r *http.Request) {
@@ -53,3 +59,45 @@ func indexPage(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 type searchPage struct {
 	ApiKey string
 }
+
+// up is for testing that the app has started e.g., for with load balancers.
+// It indicates the app is started.  It may still be serving errors.
+// Not useful for inclusion in app metrics so weft not used.
+func up(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		w.Header().Set("Surrogate-Control", "max-age=86400")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	w.Write([]byte("<html><head></head><body>up</body></html>"))
+	log.Print("up ok")
+}
+
+// soh is for external service probes.
+// writes a service unavailable error to w if the service is not working.
+// Not useful for inclusion in app metrics so weft not used.
+func soh(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		w.Header().Set("Surrogate-Control", "max-age=86400")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var c int
+
+	if err := db.QueryRow("SELECT 1").Scan(&c); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("<html><head></head><body>service error</body></html>"))
+		log.Printf("ERROR: soh service error %s", err)
+		return
+	}
+
+	w.Write([]byte("<html><head></head><body>ok</body></html>"))
+	log.Print("soh ok")
+}
+

--- a/sc3ml-to-quakeml/handlers_auto.go
+++ b/sc3ml-to-quakeml/handlers_auto.go
@@ -4,98 +4,96 @@ package main
 // It was created with weftgenapi from github.com/GeoNet/weft/weftgenapi
 
 import (
-"bytes"
-"github.com/GeoNet/weft"
-"net/http"
-"io/ioutil"
+	"bytes"
+	"github.com/GeoNet/weft"
+	"io/ioutil"
+	"net/http"
 )
 
 var mux = http.NewServeMux()
 
-
 func init() {
-mux.HandleFunc("/api-docs", weft.MakeHandlerPage(docHandler))
-mux.HandleFunc("/csv/1.0.0/", weft.MakeHandlerAPI(csv1_0_0sHandler))
-mux.HandleFunc("/quakeml/1.2/", weft.MakeHandlerAPI(quakeml1_2sHandler))
-mux.HandleFunc("/quakeml-rt/1.2/", weft.MakeHandlerAPI(quakeml_rt1_2sHandler))
+	mux.HandleFunc("/api-docs", weft.MakeHandlerPage(docHandler))
+	mux.HandleFunc("/csv/1.0.0/", weft.MakeHandlerAPI(csv1_0_0sHandler))
+	mux.HandleFunc("/quakeml/1.2/", weft.MakeHandlerAPI(quakeml1_2sHandler))
+	mux.HandleFunc("/quakeml-rt/1.2/", weft.MakeHandlerAPI(quakeml_rt1_2sHandler))
 }
 
 func docHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-switch r.Method {
-case "GET":
-by, err := ioutil.ReadFile("assets/api-docs/index.html")
-if err != nil {
-return weft.InternalServerError(err)
-}
-b.Write(by)
-return &weft.StatusOK
-default:
-return &weft.MethodNotAllowed
-}
+	switch r.Method {
+	case "GET":
+		by, err := ioutil.ReadFile("assets/api-docs/index.html")
+		if err != nil {
+			return weft.InternalServerError(err)
+		}
+		b.Write(by)
+		return &weft.StatusOK
+	default:
+		return &weft.MethodNotAllowed
+	}
 }
 func csv1_0_0sHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-switch r.Method {
-case "GET":
-switch r.Header.Get("Accept") {
-case "text/csv":
-if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-return res
-}
-h.Set("Content-Type", "text/csv")
-return csv(r, h, b)
-default:
-if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-return res
-}
-h.Set("Content-Type", "text/csv")
-return csv(r, h, b)
-}
-default:
-return &weft.MethodNotAllowed
-}
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "text/csv":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "text/csv")
+			return csv(r, h, b)
+		default:
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "text/csv")
+			return csv(r, h, b)
+		}
+	default:
+		return &weft.MethodNotAllowed
+	}
 }
 
 func quakeml1_2sHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-switch r.Method {
-case "GET":
-switch r.Header.Get("Accept") {
-case "text/xml":
-if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-return res
-}
-h.Set("Content-Type", "text/xml")
-return quakeml12(r, h, b)
-default:
-if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-return res
-}
-h.Set("Content-Type", "text/xml")
-return quakeml12(r, h, b)
-}
-default:
-return &weft.MethodNotAllowed
-}
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "text/xml":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "text/xml")
+			return quakeml12(r, h, b)
+		default:
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "text/xml")
+			return quakeml12(r, h, b)
+		}
+	default:
+		return &weft.MethodNotAllowed
+	}
 }
 
 func quakeml_rt1_2sHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-switch r.Method {
-case "GET":
-switch r.Header.Get("Accept") {
-case "text/xml":
-if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-return res
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "text/xml":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "text/xml")
+			return quakeml12RT(r, h, b)
+		default:
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "text/xml")
+			return quakeml12RT(r, h, b)
+		}
+	default:
+		return &weft.MethodNotAllowed
+	}
 }
-h.Set("Content-Type", "text/xml")
-return quakeml12RT(r, h, b)
-default:
-if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-return res
-}
-h.Set("Content-Type", "text/xml")
-return quakeml12RT(r, h, b)
-}
-default:
-return &weft.MethodNotAllowed
-}
-}
-

--- a/sc3ml-to-quakeml/routes_test.go
+++ b/sc3ml-to-quakeml/routes_test.go
@@ -14,6 +14,10 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/csv/1.0.0/2016p500086/event"},
 	{ID: wt.L(), URL: "/csv/1.0.0/2016p500086/picks"},
 	{ID: wt.L(), URL: "/csv/1.0.0/2016p500086/event/picks"},
+
+	// soh routes
+	{ID: wt.L(), URL: "/soh"},
+	{ID: wt.L(), URL: "/soh/up"},
 }
 
 func TestRoutes(t *testing.T) {

--- a/sc3ml-to-quakeml/server.go
+++ b/sc3ml-to-quakeml/server.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"time"
 	_ "github.com/GeoNet/log/logentries"
+	"github.com/GeoNet/weft"
+	"bytes"
 )
 
 var (
@@ -13,7 +15,13 @@ var (
 )
 
 func init() {
+	mux.HandleFunc("/", weft.MakeHandlerPage(home))
 	mux.HandleFunc("/health", health)
+
+	// routes for balancers and probes.
+	mux.HandleFunc("/soh/up", http.HandlerFunc(up))
+	mux.HandleFunc("/soh", http.HandlerFunc(soh))
+
 }
 
 func main() {
@@ -27,3 +35,49 @@ health does not require auth - for use with AWS EB load balancer checks.
 func health(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("ok"))
 }
+
+// up is for testing that the app has started e.g., for with load balancers.
+// It indicates the app is started.  It may still be serving errors.
+// Not useful for inclusion in app metrics so weft not used.
+func up(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		w.Header().Set("Surrogate-Control", "max-age=86400")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	w.Write([]byte("<html><head></head><body>up</body></html>"))
+	log.Print("up ok")
+}
+
+// soh is for external service probes.
+// writes a service unavailable error to w if the service is not working.
+// Not useful for inclusion in app metrics so weft not used.
+func soh(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		w.Header().Set("Surrogate-Control", "max-age=86400")
+		w.WriteHeader(http.StatusBadRequest)
+		log.Print("out")
+		return
+	}
+
+	// TODO - is there a resource to test?
+	// should we fetch SC3ML from S3 here?
+	// would be a lot of overhead for a probe.
+
+	w.Write([]byte("<html><head></head><body>ok</body></html>"))
+	log.Print("soh ok")
+}
+
+func home(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		return res
+	}
+
+	return &weft.NotFound
+}
+

--- a/wfs/quakes_test.go
+++ b/wfs/quakes_test.go
@@ -70,6 +70,10 @@ var (
 		{ID: wt.L(), URL: url_kml + "&" + cql2, Content: CONTENT_TYPE_KML, Accept: CONTENT_TYPE_KML},
 		{ID: wt.L(), URL: url_kml + "&" + cql3, Content: CONTENT_TYPE_KML, Accept: CONTENT_TYPE_KML},
 		{ID: wt.L(), URL: url_kml + "&" + cql4, Content: CONTENT_TYPE_KML, Accept: CONTENT_TYPE_KML},
+
+		// soh routes
+		{ID: wt.L(), URL: "/soh"},
+		{ID: wt.L(), URL: "/soh/up"},
 	}
 )
 

--- a/wfs/router.go
+++ b/wfs/router.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+
 	"bytes"
 	"github.com/GeoNet/weft"
 	"html/template"
 	"net/http"
+	"log"
 )
 
 var (
@@ -29,6 +31,10 @@ func init() {
 	serveMux.HandleFunc("/geonet/wms/kml", weft.MakeHandlerAPI(getQuakesKml))
 	serveMux.HandleFunc("/geonet/ows", weft.MakeHandlerAPI(getQuakesWfs))
 	serveMux.HandleFunc("/", weft.MakeHandlerPage(indexPage))
+
+	// routes for balancers and probes.
+	serveMux.HandleFunc("/soh/up", http.HandlerFunc(up))
+	serveMux.HandleFunc("/soh", http.HandlerFunc(soh))
 }
 
 func router(w http.ResponseWriter, r *http.Request) {
@@ -50,4 +56,45 @@ func indexPage(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	}
 
 	return &weft.StatusOK
+}
+
+// up is for testing that the app has started e.g., for with load balancers.
+// It indicates the app is started.  It may still be serving errors.
+// Not useful for inclusion in app metrics so weft not used.
+func up(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		w.Header().Set("Surrogate-Control", "max-age=86400")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	w.Write([]byte("<html><head></head><body>up</body></html>"))
+	log.Print("up ok")
+}
+
+// soh is for external service probes.
+// writes a service unavailable error to w if the service is not working.
+// Not useful for inclusion in app metrics so weft not used.
+func soh(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		w.Header().Set("Surrogate-Control", "max-age=86400")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var c int
+
+	if err := db.QueryRow("SELECT 1").Scan(&c); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("<html><head></head><body>service error</body></html>"))
+		log.Printf("ERROR: soh service error %s", err)
+		return
+	}
+
+	w.Write([]byte("<html><head></head><body>ok</body></html>"))
+	log.Print("soh ok")
 }


### PR DESCRIPTION
This adds soh routes:

* /soh for external service status probing (server density at the moment)
* /soh/up for use with aws load balancers so that they can insert the container as soon as it's started.
* removes the use of weft from the existing soh routes.

They don't use weft as there is not point in having these in our app metrics. This means there is a little bit of header setting that usually happens in weft.

I plan to add these to all our web projects (consistently).