### PR TITLE
Add endpoint "/quakes/services" and "/quake/services" to geonet-rest in order to provide existing www.geonet.org.nz/*/services api

### DIFF
--- a/geonet-rest/felt.go
+++ b/geonet-rest/felt.go
@@ -3,9 +3,9 @@ package main
 import (
 	"bytes"
 	"errors"
+	"github.com/GeoNet/weft"
 	"io/ioutil"
 	"net/http"
-	"github.com/GeoNet/weft"
 )
 
 const feltURL = "http://felt.geonet.org.nz/services/reports/"

--- a/geonet-rest/intensity.go
+++ b/geonet-rest/intensity.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
-	"net/http"
 	"github.com/GeoNet/weft"
+	"net/http"
 )
 
 func intensityMeasuredLatestV1(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {

--- a/geonet-rest/intensityProto.go
+++ b/geonet-rest/intensityProto.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bytes"
-	"net/http"
-	"github.com/GeoNet/weft"
 	"github.com/GeoNet/haz"
+	"github.com/GeoNet/weft"
 	"github.com/golang/protobuf/proto"
+	"net/http"
 	"time"
 )
 

--- a/geonet-rest/intensityProto_test.go
+++ b/geonet-rest/intensityProto_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"github.com/GeoNet/haz"
 	wt "github.com/GeoNet/weft/wefttest"
+	"github.com/golang/protobuf/proto"
 	"math"
 	"testing"
-	"github.com/GeoNet/haz"
-	"github.com/golang/protobuf/proto"
 )
 
 func TestIntensityMeasuredProto(t *testing.T) {
@@ -26,10 +26,10 @@ func TestIntensityMeasuredProto(t *testing.T) {
 	if len(i.Mmi) != 1 {
 		t.Error("found wrong number of intensities.")
 	}
-	if math.Abs(i.Mmi[0].Longitude - 175.49) > tolerance {
+	if math.Abs(i.Mmi[0].Longitude-175.49) > tolerance {
 		t.Error("incorrect Longitude")
 	}
-	if math.Abs(i.Mmi[0].Latitude + 40.2) > tolerance {
+	if math.Abs(i.Mmi[0].Latitude+40.2) > tolerance {
 		t.Error("incorrect Latitude")
 	}
 	if i.Mmi[0].Mmi != 4 {
@@ -56,10 +56,10 @@ func TestIntensityReportedLatestProto(t *testing.T) {
 	if len(i.Mmi) != 1 {
 		t.Error("found wrong number of intensities.")
 	}
-	if math.Abs(i.Mmi[0].Longitude - 176.489868) > tolerance {
+	if math.Abs(i.Mmi[0].Longitude-176.489868) > tolerance {
 		t.Error("incorrect Longitude")
 	}
-	if math.Abs(i.Mmi[0].Latitude + 40.201721) > tolerance {
+	if math.Abs(i.Mmi[0].Latitude+40.201721) > tolerance {
 		t.Error("incorrect Latitude")
 	}
 	if i.Mmi[0].Mmi != 6 {
@@ -105,10 +105,10 @@ func TestIntensityReportedProto(t *testing.T) {
 	if len(i.Mmi) != 1 {
 		t.Error("found wrong number of intensities.")
 	}
-	if math.Abs(i.Mmi[0].Longitude - 176.489868) > tolerance {
+	if math.Abs(i.Mmi[0].Longitude-176.489868) > tolerance {
 		t.Error("incorrect Longitude")
 	}
-	if math.Abs(i.Mmi[0].Latitude + 40.201721) > tolerance {
+	if math.Abs(i.Mmi[0].Latitude+40.201721) > tolerance {
 		t.Error("incorrect Latitude")
 	}
 	if i.Mmi[0].Mmi != 6 {

--- a/geonet-rest/intensityV2.go
+++ b/geonet-rest/intensityV2.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"bytes"
+	"github.com/GeoNet/weft"
 	"net/http"
 	"time"
-	"github.com/GeoNet/weft"
 )
 
 func intensityV2(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {

--- a/geonet-rest/log.go
+++ b/geonet-rest/log.go
@@ -11,4 +11,3 @@ func init() {
 		log.SetPrefix(Prefix + " ")
 	}
 }
-

--- a/geonet-rest/news.go
+++ b/geonet-rest/news.go
@@ -4,17 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"github.com/GeoNet/haz"
+	"github.com/GeoNet/weft"
+	"github.com/golang/protobuf/proto"
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"github.com/GeoNet/weft"
-	"github.com/GeoNet/haz"
 	"time"
-	"github.com/golang/protobuf/proto"
 )
 
 const (
-	mlink = "http://info.geonet.org.nz/m/view-rendered-page.action?abstractPageId="
+	mlink   = "http://info.geonet.org.nz/m/view-rendered-page.action?abstractPageId="
 	newsURL = "http://info.geonet.org.nz/createrssfeed.action?types=blogpost&spaces=conf_all&title=GeoNet+News+RSS+Feed&labelString%3D&excludedSpaceKeys%3D&sort=created&maxResults=10&timeSpan=500&showContent=true&publicFeed=true&confirm=Create+RSS+Feed"
 )
 
@@ -49,7 +49,7 @@ func unmarshalNews(b []byte) (f Feed, err error) {
 
 	// Copy the story link and make the link to the
 	// mobile friendly version of the story.
-	for i, _ := range f.Entries {
+	for i := range f.Entries {
 		f.Entries[i].Href = f.Entries[i].Link.Href
 		f.Entries[i].MHref = mlink + strings.Split(f.Entries[i].Id, "-")[1]
 	}
@@ -117,7 +117,7 @@ func newsProto(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	for _, v := range f.Entries {
 		s := haz.Story{
 			Title: v.Title,
-			Link: v.Link.Href,
+			Link:  v.Link.Href,
 		}
 
 		t, err := time.Parse(time.RFC3339, v.Published)

--- a/geonet-rest/newsProto_test.go
+++ b/geonet-rest/newsProto_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	wt "github.com/GeoNet/weft/wefttest"
-	"testing"
 	"github.com/GeoNet/haz"
+	wt "github.com/GeoNet/weft/wefttest"
 	"github.com/golang/protobuf/proto"
+	"testing"
 )
 
 func TestNewsProto(t *testing.T) {

--- a/geonet-rest/quake.go
+++ b/geonet-rest/quake.go
@@ -3,8 +3,8 @@ package main
 import (
 	"bytes"
 	"github.com/GeoNet/haz/msg"
-	"net/http"
 	"github.com/GeoNet/weft"
+	"net/http"
 )
 
 func quakeV1(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {

--- a/geonet-rest/quakeProto.go
+++ b/geonet-rest/quakeProto.go
@@ -2,16 +2,16 @@ package main
 
 import (
 	"bytes"
-	"github.com/GeoNet/weft"
-	"net/http"
-	"github.com/GeoNet/haz"
-	"github.com/golang/protobuf/proto"
-	"time"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"github.com/GeoNet/haz"
 	"github.com/GeoNet/haz/sc3ml"
+	"github.com/GeoNet/weft"
+	"github.com/golang/protobuf/proto"
+	"io/ioutil"
+	"net/http"
 	"strings"
+	"time"
 )
 
 const s3 = "http://seiscompml07.s3-website-ap-southeast-2.amazonaws.com/"
@@ -92,7 +92,6 @@ func quakeStatsProto(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resu
 		q.Week[k] = v
 	}
 	rows.Close()
-
 
 	var by []byte
 
@@ -249,7 +248,7 @@ func quakeTechnicalProto(r *http.Request, h http.Header, b *bytes.Buffer) *weft.
 		return res
 	}
 
-	by, res := getBytes(s3 + strings.TrimPrefix(r.URL.Path, "/quake/technical/") + ".xml", "")
+	by, res := getBytes(s3+strings.TrimPrefix(r.URL.Path, "/quake/technical/")+".xml", "")
 	if !res.Ok {
 		return res
 	}

--- a/geonet-rest/quakeProto_test.go
+++ b/geonet-rest/quakeProto_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"github.com/GeoNet/haz"
 	wt "github.com/GeoNet/weft/wefttest"
+	"github.com/golang/protobuf/proto"
 	"math"
 	"testing"
-	"github.com/GeoNet/haz"
-	"github.com/golang/protobuf/proto"
 	"time"
 )
 
@@ -36,16 +36,16 @@ func TestQuakeProto(t *testing.T) {
 	if q.Mmi != 4 {
 		t.Error("incorrect MMI")
 	}
-	if math.Abs(q.Depth - 20.334389) > tolerance {
+	if math.Abs(q.Depth-20.334389) > tolerance {
 		t.Error("incorrect depth")
 	}
-	if math.Abs(q.Magnitude - 4.027879) > tolerance {
+	if math.Abs(q.Magnitude-4.027879) > tolerance {
 		t.Error("incorrect magnitude")
 	}
-	if math.Abs(q.Longitude - 172.94479) > tolerance {
+	if math.Abs(q.Longitude-172.94479) > tolerance {
 		t.Error("incorrect Longitude")
 	}
-	if math.Abs(q.Latitude + 43.359699) > tolerance {
+	if math.Abs(q.Latitude+43.359699) > tolerance {
 		t.Error("incorrect Latitude")
 	}
 
@@ -55,7 +55,7 @@ func TestQuakeProto(t *testing.T) {
 
 	tm := time.Unix(q.Time.Sec, q.Time.Nsec)
 
-	if math.Abs(float64(time.Now().UTC().Sub(tm) / time.Second)) > 10 {
+	if math.Abs(float64(time.Now().UTC().Sub(tm)/time.Second)) > 10 {
 		t.Error("time should be closer to now.  The time in the test data is reset when it is loaded. ")
 	}
 }
@@ -95,16 +95,16 @@ func TestQuakesProto(t *testing.T) {
 			if q.Mmi != 4 {
 				t.Error("incorrect MMI")
 			}
-			if math.Abs(q.Depth - 20.334389) > tolerance {
+			if math.Abs(q.Depth-20.334389) > tolerance {
 				t.Error("incorrect depth")
 			}
-			if math.Abs(q.Magnitude - 4.027879) > tolerance {
+			if math.Abs(q.Magnitude-4.027879) > tolerance {
 				t.Error("incorrect magnitude")
 			}
-			if math.Abs(q.Longitude - 172.94479) > tolerance {
+			if math.Abs(q.Longitude-172.94479) > tolerance {
 				t.Error("incorrect Longitude")
 			}
-			if math.Abs(q.Latitude + 43.359699) > tolerance {
+			if math.Abs(q.Latitude+43.359699) > tolerance {
 				t.Error("incorrect Latitude")
 			}
 
@@ -114,7 +114,7 @@ func TestQuakesProto(t *testing.T) {
 
 			tm := time.Unix(q.Time.Sec, q.Time.Nsec)
 
-			if math.Abs(float64(time.Now().UTC().Sub(tm) / time.Second)) > 10 {
+			if math.Abs(float64(time.Now().UTC().Sub(tm)/time.Second)) > 10 {
 				t.Error("time should be closer to now.  The time in the test data is reset when it is loaded. ")
 			}
 		}
@@ -164,16 +164,16 @@ func TestQuakeHistoryProto(t *testing.T) {
 			if q.Mmi != 4 {
 				t.Error("incorrect MMI")
 			}
-			if math.Abs(q.Depth - 20.334389) > tolerance {
+			if math.Abs(q.Depth-20.334389) > tolerance {
 				t.Error("incorrect depth")
 			}
-			if math.Abs(q.Magnitude - 4.027879) > tolerance {
+			if math.Abs(q.Magnitude-4.027879) > tolerance {
 				t.Error("incorrect magnitude")
 			}
-			if math.Abs(q.Longitude - 172.94479) > tolerance {
+			if math.Abs(q.Longitude-172.94479) > tolerance {
 				t.Error("incorrect Longitude")
 			}
-			if math.Abs(q.Latitude + 43.359699) > tolerance {
+			if math.Abs(q.Latitude+43.359699) > tolerance {
 				t.Error("incorrect Latitude")
 			}
 
@@ -183,7 +183,7 @@ func TestQuakeHistoryProto(t *testing.T) {
 
 			tm := time.Unix(q.Time.Sec, q.Time.Nsec)
 
-			if math.Abs(float64(time.Now().UTC().Sub(tm) / time.Second)) > 10 {
+			if math.Abs(float64(time.Now().UTC().Sub(tm)/time.Second)) > 10 {
 				t.Error("time should be closer to now.  The time in the test data is reset when it is loaded. ")
 			}
 		}

--- a/geonet-rest/quakeV2_test.go
+++ b/geonet-rest/quakeV2_test.go
@@ -292,7 +292,7 @@ func TestQuakeStatsV2(t *testing.T) {
 		t.Errorf("expected 1 for daily rate, got %d", len(m.Rate.PerDay))
 	}
 
-	for k, _ := range m.Rate.PerDay {
+	for k := range m.Rate.PerDay {
 		if m.Rate.PerDay[k] != 2 {
 			t.Errorf("expected 2 quakes for day %s", k)
 		}

--- a/geonet-rest/quakeWWW.go
+++ b/geonet-rest/quakeWWW.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"github.com/GeoNet/weft"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	allMmi             = -1
+	feltMmi            = 3
+	defaultRecordCount = 30
+	quakesNZServiceLen = 35 // len("/quakes/services/quakes/newzealand/")
+)
+
+func quakesWWWall(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		return res
+	}
+	var d string
+	err := db.QueryRow(quakesWWWSQL, allMmi, defaultRecordCount).Scan(&d)
+	if err != nil {
+		return weft.ServiceUnavailableError(err)
+	}
+
+	b.WriteString(d)
+	h.Set("Content-Type", JSON)
+	return &weft.StatusOK
+}
+
+func quakesWWWfelt(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		return res
+	}
+	var d string
+	err := db.QueryRow(quakesNZWWWSQL, feltMmi, defaultRecordCount).Scan(&d)
+	if err != nil {
+		return weft.ServiceUnavailableError(err)
+	}
+
+	b.WriteString(d)
+	h.Set("Content-Type", JSON)
+	return &weft.StatusOK
+}
+
+func quakesWWWnz(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		return res
+	}
+
+	path := r.URL.Path[quakesNZServiceLen:] // ..."3/100.json"
+	tokens := strings.Split(path, "/")
+	if len(tokens) != 2 {
+		return weft.BadRequest("Bad URL path.")
+	}
+
+	var mmi int
+	var err error
+	var count int
+	if mmi, err = strconv.Atoi(tokens[0]); err != nil {
+		return weft.BadRequest("Bad URL path. Invalid mmi.")
+	}
+
+	if count, err = strconv.Atoi(tokens[1][:len(tokens[1])-5]); err != nil { // len(".json")
+		return weft.BadRequest("Bad URL path. Invalid count.")
+	}
+
+	var d string
+	err = db.QueryRow(quakesNZWWWSQL, mmi, count).Scan(&d)
+	if err != nil {
+		return weft.ServiceUnavailableError(err)
+	}
+
+	b.WriteString(d)
+	h.Set("Content-Type", JSON)
+	return &weft.StatusOK
+}
+
+func quakeWWW(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+		return res
+	}
+
+	publicID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/quake/services/quake/"), ".json")
+	if publicID=="" {
+		return weft.BadRequest("invalid publicID path: " + r.URL.Path)
+	}
+
+
+	var d string
+	err := db.QueryRow(quakeWWWSQL, publicID).Scan(&d)
+	if err != nil {
+		return weft.ServiceUnavailableError(err)
+	}
+
+	b.WriteString(d)
+	h.Set("Content-Type", JSON)
+	return &weft.StatusOK
+}

--- a/geonet-rest/quakeWWW_test.go
+++ b/geonet-rest/quakeWWW_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	wt "github.com/GeoNet/weft/wefttest"
+	"math"
+	"testing"
+	"time"
+)
+
+type quakeWWWFeatures struct {
+	Features []quakeWWWFeature
+}
+
+type quakeWWWFeature struct {
+	Properties quakeWWWProperties
+	Geometry   geometry
+}
+
+type quakeWWWProperties struct {
+	PublicID         string
+	OriginTime       string
+	Depth, Magnitude float64
+	Status           string
+	Intensity        string
+	Agency           string
+	UpdateTime       string
+}
+
+const (
+	timeFmt = "2006-01-02 15:04:05"
+)
+
+func TestQuakesWWW(t *testing.T) {
+	setup()
+	defer teardown()
+
+	b, err := wt.Request{Accept: JSON, URL: "/quakes/services/all.json"}.Do(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var quakes quakeWWWFeatures
+
+	err = json.Unmarshal(b, &quakes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(quakes.Features) != 2 {
+		t.Error("found wrong number of quakes")
+	}
+
+	var found bool
+
+	for _, q := range quakes.Features {
+		if q.Properties.PublicID == "2013p407387" {
+			found = true
+			if q.Properties.Intensity != "moderate" {
+				t.Error("incorrect intensity")
+			}
+			if q.Properties.Agency != "WEL(GNS_Primary)" {
+				t.Error("incorrect agency")
+			}
+			if q.Properties.Status != "reviewed" {
+				t.Error("incorrect status")
+			}
+			if math.Abs(q.Properties.Depth-20.334389) > tolerance {
+				t.Error("incorrect depth")
+			}
+			if math.Abs(q.Properties.Magnitude-4.027879) > tolerance {
+				t.Error("incorrect magnitude")
+			}
+			if math.Abs(q.Geometry.Longitude()-172.94479) > tolerance {
+				t.Error("incorrect Longitude")
+			}
+			if math.Abs(q.Geometry.Latitude()+43.359699) > tolerance {
+				t.Error("incorrect Latitude")
+			}
+
+			tm, _ := time.Parse(timeFmt, q.Properties.OriginTime)
+			if math.Abs(float64(time.Now().UTC().Sub(tm)/time.Second)) > 10 {
+				t.Error("time should be closer to now.  The time in the test data is reset when it is loaded. ")
+			}
+		}
+	}
+
+	if !found {
+		t.Error("didn't find quake 2013p407387 in the list of Features.")
+	}
+
+	b, err = wt.Request{Accept: JSON, URL: "/quakes/services/felt.json"}.Do(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	quakes = quakeWWWFeatures{}
+
+	err = json.Unmarshal(b, &quakes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(quakes.Features) != 2 {
+		t.Error("found wrong number of quakes")
+	}
+
+	b, err = wt.Request{Accept: JSON, URL: "/quakes/services/quakes/newzealand/5/100.json"}.Do(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	quakes = quakeWWWFeatures{}
+
+	err = json.Unmarshal(b, &quakes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(quakes.Features) != 1 {
+		t.Error("found wrong number of quakes")
+	}
+}
+
+func TestQuakeWWW(t *testing.T) {
+	setup()
+	defer teardown()
+
+	b, err := wt.Request{Accept: JSON, URL: "/quake/services/quake/2013p407387.json"}.Do(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var quakes quakeWWWFeatures
+
+	err = json.Unmarshal(b, &quakes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(quakes.Features) != 1 {
+		t.Error("found more than 1 quake")
+	}
+
+	var found bool
+
+	for _, q := range quakes.Features {
+		if q.Properties.PublicID == "2013p407387" {
+			found = true
+			if q.Properties.Intensity != "moderate" {
+				t.Error("incorrect intensity")
+			}
+			if q.Properties.Agency != "WEL(GNS_Primary)" {
+				t.Error("incorrect agency")
+			}
+			if q.Properties.Status != "reviewed" {
+				t.Error("incorrect status")
+			}
+			if math.Abs(q.Properties.Depth-20.334389) > tolerance {
+				t.Error("incorrect depth")
+			}
+			if math.Abs(q.Properties.Magnitude-4.027879) > tolerance {
+				t.Error("incorrect magnitude")
+			}
+			if math.Abs(q.Geometry.Longitude()-172.94479) > tolerance {
+				t.Error("incorrect Longitude")
+			}
+			if math.Abs(q.Geometry.Latitude()+43.359699) > tolerance {
+				t.Error("incorrect Latitude")
+			}
+
+			tm, _ := time.Parse(timeFmt, q.Properties.OriginTime)
+			if math.Abs(float64(time.Now().UTC().Sub(tm)/time.Second)) > 10 {
+				t.Error("time should be closer to now.  The time in the test data is reset when it is loaded. ")
+			}
+		}
+	}
+
+	if !found {
+		t.Error("didn't find quake 2013p407387 in the list of Features.")
+	}
+}

--- a/geonet-rest/routes.go
+++ b/geonet-rest/routes.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"net/http"
 	"github.com/GeoNet/weft"
+	"net/http"
 )
 
 var (
@@ -11,7 +11,7 @@ var (
 	muxV2GeoJSON *http.ServeMux
 	muxV2JSON    *http.ServeMux
 	muxDefault   *http.ServeMux
-	muxProto *http.ServeMux
+	muxProto     *http.ServeMux
 )
 
 func init() {

--- a/geonet-rest/routes.go
+++ b/geonet-rest/routes.go
@@ -64,6 +64,10 @@ func init() {
 	muxDefault.HandleFunc("/intensity", weft.MakeHandlerAPI(intensityV2))
 	muxDefault.HandleFunc("/news/geonet", weft.MakeHandlerAPI(newsV2))
 	muxDefault.HandleFunc("/volcano/val", weft.MakeHandlerAPI(valV2))
+	muxDefault.HandleFunc("/quakes/services/all.json", weft.MakeHandlerAPI(quakesWWWall))
+	muxDefault.HandleFunc("/quakes/services/felt.json", weft.MakeHandlerAPI(quakesWWWfelt))
+	muxDefault.HandleFunc("/quakes/services/quakes/newzealand/", weft.MakeHandlerAPI(quakesWWWnz))
+	muxDefault.HandleFunc("/quake/services/quake/", weft.MakeHandlerAPI(quakeWWW))
 
 	for _, v := range []*http.ServeMux{muxV1JSON, muxV2JSON, muxV1GeoJSON, muxV2GeoJSON, muxDefault, muxProto} {
 		v.HandleFunc("/", weft.MakeHandlerPage(docs))

--- a/geonet-rest/server.go
+++ b/geonet-rest/server.go
@@ -22,7 +22,7 @@ const (
 	V1JSON    = "application/json;version=1"
 	V2GeoJSON = "application/vnd.geo+json;version=2"
 	V2JSON    = "application/json;version=2"
-	protobuf = "application/x-protobuf"
+	protobuf  = "application/x-protobuf"
 )
 
 // These are for CAP format and Atom which is not versioned by Accept.

--- a/geonet-rest/server.go
+++ b/geonet-rest/server.go
@@ -22,6 +22,7 @@ const (
 	V1JSON    = "application/json;version=1"
 	V2GeoJSON = "application/vnd.geo+json;version=2"
 	V2JSON    = "application/json;version=2"
+	JSON      = "application/json"
 	protobuf  = "application/x-protobuf"
 )
 

--- a/geonet-rest/server_test.go
+++ b/geonet-rest/server_test.go
@@ -13,7 +13,7 @@ import (
 const tolerance float64 = 0.0001
 
 var measuredTest = []msg.Intensity{
-	msg.Intensity{Source: "NZ.WEL",
+	{Source: "NZ.WEL",
 		Longitude: 175.49,
 		Latitude:  -40.2,
 		Time:      time.Now().UTC(),
@@ -22,19 +22,19 @@ var measuredTest = []msg.Intensity{
 }
 
 var reportedTest = []msg.Intensity{
-	msg.Intensity{Source: "id1",
+	{Source: "id1",
 		Longitude: 176.49,
 		Latitude:  -40.2,
 		Time:      time.Now().UTC(),
 		MMI:       4,
 	},
-	msg.Intensity{Source: "id2",
+	{Source: "id2",
 		Longitude: 176.49,
 		Latitude:  -40.2,
 		Time:      time.Now().UTC(),
 		MMI:       5,
 	},
-	msg.Intensity{Source: "id3",
+	{Source: "id3",
 		Longitude: 176.49,
 		Latitude:  -40.2,
 		Time:      time.Now().UTC(),

--- a/geonet-rest/soh.go
+++ b/geonet-rest/soh.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"bytes"
+	"github.com/GeoNet/weft"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
-	"github.com/GeoNet/weft"
-	"log"
 )
 
 const head = `<html xmlns="http://www.w3.org/1999/xhtml"><head><title>GeoNet - SOH</title><style type="text/css">
@@ -99,7 +99,7 @@ func impactSOH(w http.ResponseWriter, r *http.Request) {
 
 	var meas int
 	err := db.QueryRow("select count(*) from impact.intensity_measured").Scan(&meas)
-	if err != nil  {
+	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		log.Printf("ERROR: %v", err)
 	}
@@ -114,7 +114,6 @@ func impactSOH(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`<h3>Impact</h3>`))
 
 	w.Write([]byte(`<table><tr><th>Impact</th><th>Count</th></tr>`))
-
 
 	if err == nil {
 		if meas < 50 {

--- a/geonet-rest/sql_queries.go
+++ b/geonet-rest/sql_queries.go
@@ -220,3 +220,87 @@ WHERE in_newzealand AND NOT deleted
 SELECT magnitude, count(magnitude)
 FROM mags where  time >= (now() - interval '%d days') group by magnitude
 `
+
+const quakesNZWWWSQL = `SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type,
+COALESCE(array_to_json(array_agg(f)), '[]') as features,
+row_to_json(
+(SELECT n FROM (SELECT 'EPSG' as type,
+	row_to_json((
+		SELECT m FROM (SELECT '4326' as "code") as m)) as properties) as n)
+) as crs
+	FROM (SELECT 'Feature' as type,
+		'quake.' || publicid as "id",
+		ST_AsGeoJSON(q.geom)::json as geometry,
+		'origin_geom' as "geometry_name",
+		row_to_json((SELECT l FROM
+			(
+				SELECT
+				publicid AS "publicid",
+				to_char(time, 'YYYY-MM-DD HH24:MI:SS.US') as "origintime",
+				depth,
+				magnitude,
+				intensity,
+				status,
+				agencyid as "agency",
+				to_char(modificationtime, 'YYYY-MM-DD HH24:MI:SS.US') AS "updatetime"
+				) as l
+)) as properties FROM haz.quakeapi as q where mmid_newzealand >= $1
+AND In_newzealand = true
+ORDER BY time DESC  limit $2 ) as f) as fc`
+
+const quakesWWWSQL = `SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type,
+COALESCE(array_to_json(array_agg(f)), '[]') as features,
+row_to_json(
+(SELECT n FROM (SELECT 'EPSG' as type,
+	row_to_json((
+		SELECT m FROM (SELECT '4326' as "code") as m)) as properties) as n)
+) as crs
+	FROM (SELECT 'Feature' as type,
+		'quake.' || publicid as "id",
+		ST_AsGeoJSON(q.geom)::json as geometry,
+		'origin_geom' as "geometry_name",
+		row_to_json((SELECT l FROM
+			(
+				SELECT
+				publicid AS "publicid",
+				to_char(time, 'YYYY-MM-DD HH24:MI:SS.US') as "origintime",
+				depth,
+				magnitude,
+				intensity,
+				status,
+				agencyid as "agency",
+				to_char(modificationtime, 'YYYY-MM-DD HH24:MI:SS.US') AS "updatetime"
+				) as l
+)) as properties FROM haz.quakeapi as q where mmi >= $1
+AND In_newzealand = true
+ORDER BY time DESC  limit $2 ) as f) as fc`
+
+const quakeWWWSQL = `SELECT row_to_json(fc)
+FROM ( SELECT 'FeatureCollection' as type,
+COALESCE(array_to_json(array_agg(f)), '[]') as features,
+row_to_json(
+(SELECT n FROM (SELECT 'EPSG' as type,
+	row_to_json((
+		SELECT m FROM (SELECT '4326' as "code") as m)) as properties) as n)
+) as crs
+	FROM (SELECT 'Feature' as type,
+		'quake.' || publicid as "id",
+		ST_AsGeoJSON(q.geom)::json as geometry,
+		'origin_geom' as "geometry_name",
+		row_to_json((SELECT l FROM
+			(
+				SELECT
+				publicid AS "publicid",
+				to_char(time, 'YYYY-MM-DD HH24:MI:SS.US') as "origintime",
+				depth,
+				magnitude,
+				intensity,
+				status,
+				agencyid as "agency",
+				to_char(modificationtime, 'YYYY-MM-DD HH24:MI:SS.US') AS "updatetime"
+				) as l
+)) as properties FROM haz.quakeapi as q where publicid = $1
+AND In_newzealand = true
+ORDER BY time DESC  limit 100 ) as f) as fc`

--- a/geonet-rest/sql_queries.go
+++ b/geonet-rest/sql_queries.go
@@ -14,7 +14,6 @@ const quakeHistoryProtoSQL = `SELECT time, modificationTime, depth, magnitude, l
 				ST_Y(geom::geometry) as latitude
 			FROM haz.quakehistory WHERE publicid = $1 ORDER BY modificationtime DESC`
 
-
 const quakesProtoSQL = `SELECT publicid, time, modificationTime, depth, magnitude, locality,
 				floor(mmid_newzealand) as "mmi",
 				quality,
@@ -23,7 +22,6 @@ const quakesProtoSQL = `SELECT publicid, time, modificationTime, depth, magnitud
 			FROM haz.quakeapi where mmid_newzealand >= $1
 			AND In_newzealand = true
 			ORDER BY time DESC  limit 100`
-
 
 const quakeV2SQL = `SELECT row_to_json(fc)
 FROM ( SELECT 'FeatureCollection' as type, array_to_json(array_agg(f)) as features

--- a/geonet-rest/valid.go
+++ b/geonet-rest/valid.go
@@ -3,12 +3,12 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"github.com/GeoNet/weft"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
-	"github.com/GeoNet/weft"
 )
 
 const quakeLen = 7         //  len("/quake/")

--- a/geonet-rest/volcanoProto.go
+++ b/geonet-rest/volcanoProto.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"bytes"
-	"net/http"
-	"github.com/GeoNet/weft"
 	"database/sql"
 	"github.com/GeoNet/haz"
+	"github.com/GeoNet/weft"
 	"github.com/golang/protobuf/proto"
+	"net/http"
 )
 
 func valProto(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {

--- a/geonet-rest/volcanoProto_test.go
+++ b/geonet-rest/volcanoProto_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"github.com/GeoNet/haz"
 	wt "github.com/GeoNet/weft/wefttest"
+	"github.com/golang/protobuf/proto"
 	"math"
 	"testing"
-	"github.com/GeoNet/haz"
-	"github.com/golang/protobuf/proto"
 )
 
 func TestValProto(t *testing.T) {
@@ -45,10 +45,10 @@ func TestValProto(t *testing.T) {
 			if v.Val.Level != 1 {
 				t.Error("incorrect level")
 			}
-			if math.Abs(v.Longitude -175.563) > tolerance {
+			if math.Abs(v.Longitude-175.563) > tolerance {
 				t.Error("incorrect Longitude")
 			}
-			if math.Abs(v.Latitude +39.281) > tolerance {
+			if math.Abs(v.Latitude+39.281) > tolerance {
 				t.Error("incorrect Latitude")
 			}
 		}

--- a/geonet-rest/volcanoV2.go
+++ b/geonet-rest/volcanoV2.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
-	"net/http"
 	"github.com/GeoNet/weft"
+	"net/http"
 )
 
 func valV2(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {


### PR DESCRIPTION
Mapping:

http://www.geonet.org.nz/quakes/services/all.json -> /quakes/services/all.json
http://www.geonet.org.nz/quakes/services/felt.json -> /quakes/services/felt.json
http://www.geonet.org.nz/quakes/services/quakes/newzealand/3/100.json -> /quakes/services/quakes/newzealand/3/100.json

http://www.geonet.org.nz/quake/2016p858000.json -> /quake/services/quake/2016p858000.json