### PR TITLE
Update repo link in api docs index template

### DIFF
--- a/geonet-rest/assets/docs/index.md
+++ b/geonet-rest/assets/docs/index.md
@@ -23,7 +23,7 @@ Bugs
 
 ## Bugs
 
-The code that provide these services is available at [https://github.com/GeoNet/haz/geonet-rest](https://github.com/GeoNet/haz/geonet-rest) If you believe you have found a bug please raise an issue or pull request there.
+The code that provide these services is available at [https://github.com/GeoNet/haz/tree/master/geonet-rest](https://github.com/GeoNet/haz/tree/master/geonet-rest) If you believe you have found a bug please raise an issue or pull request there.
 
 # Endpoints
 
@@ -224,7 +224,7 @@ rate
 
 ## Quakes ## {#quakes}
 
-Rerturns quakes possibly felt in the New Zealand region during the last 365 days up to a maximum of 100 quakes.
+Returns quakes possibly felt in the New Zealand region during the last 365 days up to a maximum of 100 quakes.
 
     [GET] /quake?MMI=(int)
 


### PR DESCRIPTION
Noticed the docs link didn't work, I've simply added the `tree/master` bit but it could also be switched to the base repo i.e. `GeoNet/haz`

I can't seem to not add the newline at the end of the file. i.e

```
-[/volcano/val](/volcano/val)
\ No newline at end of file
+[/volcano/val](/volcano/val)
```
If this is important for the template to work then ditch this PR and a different editor will be needed (it didn't work via editing online either).