### PR TITLE
Proxy sensor GeoJSON from S3

### DIFF
--- a/geonet-rest/delta.go
+++ b/geonet-rest/delta.go
@@ -8,6 +8,20 @@ import (
 	"net/http"
 )
 
+// sensor geojson that has a corresponding *.geojson file in S3.
+var sensorGeoJSON = map[string]bool{
+	"accelerometer": true,
+	"barometer": true,
+	"broadbandseismometer": true,
+	"buildingarraysensor": true,
+	"hydrophone": true,
+	"microphone": true,
+	"pressuresensor": true,
+	"shortperiodboreholeseismometer": true,
+	"shortperiodseismometer": true,
+	"strongmotionsensor": true,
+}
+
 // Proxies marks.geojson from S3
 func marksV2(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
@@ -85,6 +99,38 @@ func marksV2JSON(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	}
 
 	h.Set("Content-Type", V2JSON)
+	h.Set("Surrogate-Control", maxAge3600)
+	return &weft.StatusOK
+}
+
+// Proxies sensor *.geojson from S3
+func sensorV2(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	if res := weft.CheckQuery(r, []string{"type"}, []string{}); !res.Ok {
+		return res
+	}
+
+	t := r.URL.Query().Get("type")
+	if !sensorGeoJSON[t] {
+		return &weft.NotFound
+	}
+
+	params := &s3.GetObjectInput{
+		Key:    aws.String("delta/" + t +".geojson"),
+		Bucket: aws.String("api.geonet.org.nz"),
+	}
+
+	res, err := s3Client.GetObject(params)
+	if err != nil {
+		return weft.InternalServerError(err)
+	}
+	defer res.Body.Close()
+
+	_, err = b.ReadFrom(res.Body)
+	if err != nil {
+		return weft.InternalServerError(err)
+	}
+
+	h.Set("Content-Type", V2GeoJSON)
 	h.Set("Surrogate-Control", maxAge3600)
 	return &weft.StatusOK
 }

--- a/geonet-rest/routes.go
+++ b/geonet-rest/routes.go
@@ -33,6 +33,8 @@ func init() {
 	muxV2GeoJSON.HandleFunc("/volcano/quake/", weft.MakeHandlerAPI(quakesVolcanoRegionV2))
 	muxV2GeoJSON.HandleFunc("/volcano/region/", weft.MakeHandlerAPI(volcanoRegionV2))
 	muxV2GeoJSON.HandleFunc("/delta/mark", weft.MakeHandlerAPI(marksV2))
+	muxV2GeoJSON.HandleFunc("/network/sensor", weft.MakeHandlerAPI(sensorV2))
+
 
 	muxV2JSON = http.NewServeMux()
 	muxV2JSON.HandleFunc("/news/geonet", weft.MakeHandlerAPI(newsV2))
@@ -78,6 +80,7 @@ func init() {
 	muxDefault.HandleFunc("/quakes/services/quakes/newzealand/", weft.MakeHandlerAPI(quakesWWWnz))
 	muxDefault.HandleFunc("/quake/services/quake/", weft.MakeHandlerAPI(quakeWWW))
 	muxDefault.HandleFunc("/delta/mark", weft.MakeHandlerAPI(marksV2))
+	muxDefault.HandleFunc("/network/sensor", weft.MakeHandlerAPI(sensorV2))
 
 	for _, v := range []*http.ServeMux{muxV1JSON, muxV2JSON, muxV1GeoJSON, muxV2GeoJSON, muxDefault, muxProto} {
 		v.HandleFunc("/", weft.MakeHandlerPage(docs))


### PR DESCRIPTION
Adds sensor GeoJSON services for seismic sites and other sensors that are handled the same way.  If this "sensor network" concept tests well with the users then I would change the existing /delta/gnss services to follow it.  There are the following queries available.  Some of these layers have a lot of points.

`/network/sensor?type=accelerometer` where options for type are in the list below (and the layer label for UI is in brackets).

```
accelerometer   (Acclerometer)
barometer   (Barometer)
broadbandseismometer  (Broadband Seismometer)
buildingarraysensor  (Building Array)
hydrophone  (Hydrophone)
microphone  (Microphone)
pressuresensor  (Pressure Sensor)
shortperiodboreholeseismometer  (Short Period Borehole Seismometer)
shortperiodseismometer  (Short Period Seismometer)
strongmotionsensor  (Strong Motion Sensor)
```